### PR TITLE
[Sprint 22/23 | PD-394] - [Hotfix] Fix Action Naming

### DIFF
--- a/src/akushon/action/node/action_manager.cpp
+++ b/src/akushon/action/node/action_manager.cpp
@@ -74,6 +74,9 @@ void ActionManager::load_config(const std::string & path)
     for (int i = path.length(); i < file_name.length() - extension_json.length(); i++) {
       name += file_name[i];
     }
+
+    // remove "/" from the start of the name string
+    name.erase(0, 1);
     try {
       std::ifstream file(file_name);
       nlohmann::json action_data = nlohmann::json::parse(file);


### PR DESCRIPTION
## Jira Link: 
https://ichiro-its.atlassian.net/browse/PD-394

## Description
When running soccer and pushed button stop, the program becomes unresponsive because an error occured in akushon and the akushon node breaks. The error is caused by the action name message doesn't match the naming in akushon actions variable. Action names in akushon starts with "/" because it is taken from the data directory.

## Type of Change

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [x] Manual tested.

## Checklist:

- [x] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.