### PR TITLE
Hotfix/fix grpc when run soccer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,9 +51,24 @@ add_library(${PROJECT_NAME} SHARED
   "src/${PROJECT_NAME}/node/akushon_node.cpp"
   )
 
+add_library(${PROJECT_NAME}_exported SHARED
+"src/${PROJECT_NAME}/action/model/action_name.cpp"
+"src/${PROJECT_NAME}/action/model/action.cpp"  
+"src/${PROJECT_NAME}/action/model/pose.cpp"
+"src/${PROJECT_NAME}/action/node/action_manager.cpp"
+"src/${PROJECT_NAME}/action/node/action_node.cpp"
+"src/${PROJECT_NAME}/action/process/interpolator.cpp"
+"src/${PROJECT_NAME}/action/process/joint_process.cpp"
+)
+
 target_include_directories(${PROJECT_NAME} PUBLIC  
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
+
+
+target_include_directories(${PROJECT_NAME}_exported PUBLIC  
+$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+$<INSTALL_INTERFACE:include>)
 
 ament_target_dependencies(${PROJECT_NAME}
   ament_index_cpp
@@ -65,6 +80,15 @@ ament_target_dependencies(${PROJECT_NAME}
   tachimawari_interfaces
   gRPC)
 
+  ament_target_dependencies(${PROJECT_NAME}_exported
+  ament_index_cpp
+  akushon_interfaces
+  rclcpp
+  rclcpp_action
+  std_msgs
+  tachimawari
+  tachimawari_interfaces)
+
 target_link_libraries(${PROJECT_NAME}
   gRPC::grpc++_reflection
   gRPC::grpc++  
@@ -74,6 +98,13 @@ install(DIRECTORY "include" DESTINATION ".")
 
 install(TARGETS ${PROJECT_NAME}
   EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION "lib"
+  LIBRARY DESTINATION "lib"
+  RUNTIME DESTINATION "bin"
+  INCLUDES DESTINATION "include")
+
+  install(TARGETS ${PROJECT_NAME}_exported
+  EXPORT export_${PROJECT_NAME}_exported
   ARCHIVE DESTINATION "lib"
   LIBRARY DESTINATION "lib"
   RUNTIME DESTINATION "bin"
@@ -119,5 +150,5 @@ ament_export_dependencies(
   tachimawari
   tachimawari_interfaces)
 ament_export_include_directories("include")
-ament_export_libraries(${PROJECT_NAME})
+ament_export_libraries(${PROJECT_NAME}_exported)
 ament_package()

--- a/src/akushon/config/grpc/call_data_save_config.cpp
+++ b/src/akushon/config/grpc/call_data_save_config.cpp
@@ -48,8 +48,7 @@ void CallDataSaveConfig::HandleRequest()
 {
   Config config(path_);
   try {
-    nlohmann::json akushon_data = nlohmann::json::parse(request_.json_actions());
-    config.save_config(akushon_data);
+    config.save_config(request_.json_actions());
     RCLCPP_INFO(rclcpp::get_logger("SaveConfig"), "config has been saved!");
   } catch (nlohmann::json::exception e) {
     RCLCPP_ERROR(rclcpp::get_logger("SaveConfig"), e.what());

--- a/src/akushon/config/grpc/call_data_subscribe_current_joints.cpp
+++ b/src/akushon/config/grpc/call_data_subscribe_current_joints.cpp
@@ -33,6 +33,13 @@ CallDataSubscribeCurrentJoints::CallDataSubscribeCurrentJoints(
   const std::string& path, rclcpp::Node::SharedPtr& node)
 : CallData(service, cq, path), node_(node)
 {
+  current_joint_subscription_ =
+    node_->create_subscription<tachimawari_interfaces::msg::CurrentJoints>(
+      "/joint/current_joints", 10,
+      [this](const tachimawari_interfaces::msg::CurrentJoints::SharedPtr curr_joints) {          
+        curr_joints_.joints = curr_joints->joints;
+      });
+
   Proceed();
 }  // namespace akushon
 
@@ -49,12 +56,6 @@ void CallDataSubscribeCurrentJoints::WaitForRequest()
 void CallDataSubscribeCurrentJoints::HandleRequest()
 {
   try {
-    current_joint_subscription_ =
-      node_->create_subscription<tachimawari_interfaces::msg::CurrentJoints>(
-        "/joint/current_joints", 10,
-        [this](const tachimawari_interfaces::msg::CurrentJoints::SharedPtr curr_joints) {          
-          curr_joints_.joints = curr_joints->joints;
-        });
     nlohmann::json curr_joints;
     
     for (const auto & items : curr_joints_.joints) {


### PR DESCRIPTION
## Jira Link: 

## Description

Remove 'grpc' from the exported CMake to fix conflicts (using both statically and dynamically linked libraries) when running Soccer because the exported 'grpc' is also unused in Soccer."

## Type of Change

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [ ] Manual tested.

## Checklist:

- [ ] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.