### PR TITLE
[WIP ][Feature] Implement map action for dynamic kick

### DIFF
--- a/include/akushon/action/model/action.hpp
+++ b/include/akushon/action/model/action.hpp
@@ -57,6 +57,8 @@ public:
 
   void reset();
 
+  void map_action(const Action & source_action, const Action & target_action, int target_pose_index, float source_val, float source_min, float source_max);
+
 private:
   std::string name;
 

--- a/include/akushon/action/node/action_manager.hpp
+++ b/include/akushon/action/node/action_manager.hpp
@@ -49,7 +49,7 @@ public:
   Action load_action(const nlohmann::json & action_data, const std::string & action_name) const;
 
   void start(std::string action_name, const Pose & initial_pose);
-  void start(Action & action, const Action & target_action, const Pose & initial_pose, float ball_x, float right_map_x_min_, float right_map_x_max_, float left_map_x_min_, float left_map_x_max_, bool right);
+  void start(std::string action_name, std::string target_action_name, const Pose & initial_pose, float ball_x, float right_map_x_min_, float right_map_x_max_, float left_map_x_min_, float left_map_x_max_, bool right);
   void start(const Action & action, const Pose & initial_pose);
   void brake();
   void process(int time);

--- a/include/akushon/action/node/action_manager.hpp
+++ b/include/akushon/action/node/action_manager.hpp
@@ -49,6 +49,7 @@ public:
   Action load_action(const nlohmann::json & action_data, const std::string & action_name) const;
 
   void start(std::string action_name, const Pose & initial_pose);
+  void start(Action & action, const Action & target_action, const Pose & initial_pose, float ball_x, float right_map_x_min_, float right_map_x_max_, float left_map_x_min_, float left_map_x_max_, bool right);
   void start(const Action & action, const Pose & initial_pose);
   void brake();
   void process(int time);

--- a/include/akushon/action/node/action_manager.hpp
+++ b/include/akushon/action/node/action_manager.hpp
@@ -45,6 +45,7 @@ public:
   Action get_action(std::string action_name) const;
 
   void load_config(const std::string & path);
+  void set_config(const nlohmann::json & json);
 
   Action load_action(const nlohmann::json & action_data, const std::string & action_name) const;
 
@@ -58,11 +59,17 @@ public:
 
   std::vector<tachimawari::joint::Joint> get_joints() const;
 
+  bool using_dynamic_kick;
+  double right_map_x_min;
+  double right_map_x_max;
+  double left_map_x_min;
+  double left_map_x_max;
 private:
   std::map<std::string, Action> actions;
 
   std::shared_ptr<Interpolator> interpolator;
   bool is_running;
+  std::string config_name;
 };
 
 }  // namespace akushon

--- a/include/akushon/action/node/action_manager.hpp
+++ b/include/akushon/action/node/action_manager.hpp
@@ -64,12 +64,14 @@ public:
   double right_map_x_max;
   double left_map_x_min;
   double left_map_x_max;
+
 private:
   std::map<std::string, Action> actions;
 
   std::shared_ptr<Interpolator> interpolator;
   bool is_running;
   std::string config_name;
+  std::string action_dir;
 };
 
 }  // namespace akushon

--- a/include/akushon/action/node/action_node.hpp
+++ b/include/akushon/action/node/action_node.hpp
@@ -33,6 +33,7 @@
 #include "std_msgs/msg/empty.hpp"
 #include "tachimawari_interfaces/msg/current_joints.hpp"
 #include "tachimawari_interfaces/msg/set_joints.hpp"
+#include "keisan/keisan.hpp"
 
 namespace akushon
 {
@@ -54,6 +55,7 @@ public:
   static std::string run_action_topic();
   static std::string brake_action_topic();
   static std::string status_topic();
+  static std::string ball_topic();
 
   explicit ActionNode(
     rclcpp::Node::SharedPtr node, std::shared_ptr<ActionManager> & action_manager);
@@ -68,6 +70,8 @@ private:
   void publish_status();
 
   Pose initial_pose;
+  keisan::Point2 ball_pos;
+
   rclcpp::Node::SharedPtr node;
 
   std::shared_ptr<ActionManager> action_manager;
@@ -77,6 +81,7 @@ private:
 
   rclcpp::Subscription<RunAction>::SharedPtr run_action_subscriber;
   rclcpp::Subscription<Empty>::SharedPtr brake_action_subscriber;
+  rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr ball_subscriber;
   rclcpp::Publisher<Status>::SharedPtr status_publisher;
 };
 

--- a/include/akushon/action/node/action_node.hpp
+++ b/include/akushon/action/node/action_node.hpp
@@ -31,6 +31,7 @@
 #include "akushon_interfaces/msg/status.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/empty.hpp"
+#include "std_msgs/msg/float64.hpp"
 #include "tachimawari_interfaces/msg/current_joints.hpp"
 #include "tachimawari_interfaces/msg/set_joints.hpp"
 #include "keisan/keisan.hpp"
@@ -46,6 +47,7 @@ public:
   using RunAction = akushon_interfaces::msg::RunAction;
   using SetJoints = tachimawari_interfaces::msg::SetJoints;
   using Status = akushon_interfaces::msg::Status;
+  using Float64 = std_msgs::msg::Float64;
 
   enum { READY, PLAYING };
 
@@ -70,7 +72,7 @@ private:
   void publish_status();
 
   Pose initial_pose;
-  keisan::Point2 ball_pos;
+  double ball_pos;
 
   rclcpp::Node::SharedPtr node;
 
@@ -81,7 +83,7 @@ private:
 
   rclcpp::Subscription<RunAction>::SharedPtr run_action_subscriber;
   rclcpp::Subscription<Empty>::SharedPtr brake_action_subscriber;
-  rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr ball_subscriber;
+  rclcpp::Subscription<Float64>::SharedPtr ball_subscriber;
   rclcpp::Publisher<Status>::SharedPtr status_publisher;
 };
 

--- a/include/akushon/config/utils/config.hpp
+++ b/include/akushon/config/utils/config.hpp
@@ -34,9 +34,11 @@ public:
 
   std::string get_config() const;
   void save_config(const std::string & actions_data);
+  void clear_directory(const std::string& directory_path);
 
 private:
   std::string path;
+  std::string action_dir;
 };
 
 }  // namespace akushon

--- a/src/akushon/action/model/action.cpp
+++ b/src/akushon/action/model/action.cpp
@@ -123,7 +123,7 @@ void Action::map_action(const Action & source_action, const Action & target_acti
       float new_joint_value = keisan::map(source_val, source_min, source_max, target_min, target_max);
       new_joint_value = keisan::curve(new_joint_value, target_min, target_max, float(2.0));
       new_joint_value = keisan::clamp(new_joint_value, target_min, target_max);
-      target_joints[joint].set_position_value(new_joint_value);
+      src_joints[joint].set_position_value(new_joint_value);
   }
 }
 

--- a/src/akushon/action/model/action.cpp
+++ b/src/akushon/action/model/action.cpp
@@ -110,4 +110,21 @@ void Action::reset()
   poses.clear();
 }
 
+void Action::map_action(const Action & source_action, const Action & target_action, int target_pose_index, float source_val, float source_min, float source_max)
+{
+  
+  std::vector<tachimawari::joint::Joint> src_joints = source_action.get_pose(target_pose_index).get_joints();
+  std::vector<tachimawari::joint::Joint> target_joints = target_action.get_pose(target_pose_index).get_joints();
+
+  for (int joint = 0; joint < 22; joint++)
+  {
+      float target_min = src_joints.at(joint).get_position_value();
+      float target_max = target_joints.at(joint).get_position_value();
+      float new_joint_value = keisan::map(source_val, source_min, source_max, target_min, target_max);
+      new_joint_value = keisan::curve(new_joint_value, target_min, target_max, float(2.0));
+      new_joint_value = keisan::clamp(new_joint_value, target_min, target_max);
+      target_joints[joint].set_position_value(new_joint_value);
+  }
+}
+
 }  // namespace akushon

--- a/src/akushon/action/model/action.cpp
+++ b/src/akushon/action/model/action.cpp
@@ -112,11 +112,9 @@ void Action::reset()
 
 void Action::map_action(const Action & source_action, const Action & target_action, int target_pose_index, float source_val, float source_min, float source_max)
 {
-  
   std::vector<tachimawari::joint::Joint> src_joints = source_action.get_pose(target_pose_index).get_joints();
   std::vector<tachimawari::joint::Joint> target_joints = target_action.get_pose(target_pose_index).get_joints();
-
-  for (int joint = 0; joint < 22; joint++)
+  for (int joint = 0; joint < 20; joint++)
   {
       float target_min = src_joints.at(joint).get_position_value();
       float target_max = target_joints.at(joint).get_position_value();

--- a/src/akushon/action/node/action_manager.cpp
+++ b/src/akushon/action/node/action_manager.cpp
@@ -157,6 +157,25 @@ void ActionManager::start(std::string action_name, const Pose & initial_pose)
   is_running = true;
 }
 
+void ActionManager::start(Action & action, const Action & target_action, const Pose & initial_pose, float ball_x, float right_map_x_min_, float right_map_x_max_, float left_map_x_min_, float left_map_x_max_, bool right)
+{
+  for (int pose_index = 0; pose_index < action.get_pose_count(); pose_index++) {
+    if (right)
+    {
+      {
+        action.map_action(action, target_action, pose_index, ball_x, right_map_x_min_, right_map_x_max_);
+      }
+    } else {
+        action.map_action(action, target_action, pose_index, ball_x, left_map_x_min_, left_map_x_max_);
+    }
+  }
+
+  std::vector<Action> target_actions {action};
+
+  interpolator = std::make_shared<Interpolator>(target_actions, initial_pose);
+  is_running = true;
+}
+
 void ActionManager::start(const Action & action, const Pose & initial_pose)
 {
   std::vector<Action> target_actions {action};

--- a/src/akushon/action/node/action_manager.cpp
+++ b/src/akushon/action/node/action_manager.cpp
@@ -157,18 +157,37 @@ void ActionManager::start(std::string action_name, const Pose & initial_pose)
   is_running = true;
 }
 
-void ActionManager::start(Action & action, const Action & target_action, const Pose & initial_pose, float ball_x, float right_map_x_min_, float right_map_x_max_, float left_map_x_min_, float left_map_x_max_, bool right)
+void ActionManager::start(std::string action_name, std::string target_action_name, const Pose & initial_pose, float ball_x, float right_map_x_min_, float right_map_x_max_, float left_map_x_min_, float left_map_x_max_, bool right)
 {
-  for (int pose_index = 0; pose_index < action.get_pose_count(); pose_index++) {
-    if (right)
-    {
-      action.map_action(action, target_action, pose_index, ball_x, right_map_x_min_, right_map_x_max_);
+  std::vector<Action> target_actions;
+
+  while (true) {
+    auto & action = actions.at(action_name);
+    const auto & target_action = actions.at(target_action_name);
+
+    for (int pose_index = 0; pose_index < action.get_pose_count(); pose_index++) {
+      if (right)
+      {
+        action.map_action(action, target_action, pose_index, ball_x, right_map_x_min_, right_map_x_max_);
+      } else {
+        action.map_action(action, target_action, pose_index, ball_x, left_map_x_min_, left_map_x_max_);
+      }
+    }
+
+    target_actions.push_back(action);
+
+    if (action.get_next_action() != "") {
+      std::string next_action_name = action.get_next_action();
+
+      if (actions.find(next_action_name) != actions.end()) {
+        action_name = next_action_name;
+      } else {
+        break;
+      }
     } else {
-      action.map_action(action, target_action, pose_index, ball_x, left_map_x_min_, left_map_x_max_);
+      break;
     }
   }
-
-  std::vector<Action> target_actions {action};
 
   interpolator = std::make_shared<Interpolator>(target_actions, initial_pose);
   is_running = true;

--- a/src/akushon/action/node/action_manager.cpp
+++ b/src/akushon/action/node/action_manager.cpp
@@ -162,11 +162,9 @@ void ActionManager::start(Action & action, const Action & target_action, const P
   for (int pose_index = 0; pose_index < action.get_pose_count(); pose_index++) {
     if (right)
     {
-      {
-        action.map_action(action, target_action, pose_index, ball_x, right_map_x_min_, right_map_x_max_);
-      }
+      action.map_action(action, target_action, pose_index, ball_x, right_map_x_min_, right_map_x_max_);
     } else {
-        action.map_action(action, target_action, pose_index, ball_x, left_map_x_min_, left_map_x_max_);
+      action.map_action(action, target_action, pose_index, ball_x, left_map_x_min_, left_map_x_max_);
     }
   }
 

--- a/src/akushon/action/node/action_manager.cpp
+++ b/src/akushon/action/node/action_manager.cpp
@@ -41,7 +41,7 @@ namespace akushon
 {
 
 ActionManager::ActionManager()
-: actions({}), is_running(false), config_name("dynamic_kick.json")
+: actions({}), is_running(false), config_name("dynamic_kick.json"), action_dir("actions/")
 {
   interpolator = std::make_shared<Interpolator>(std::vector<Action>(), Pose(""));
 }
@@ -80,14 +80,11 @@ void ActionManager::load_config(const std::string & path)
       throw ex;
   }
 
-  for (const auto & entry : std::filesystem::directory_iterator(path)) {
+  for (const auto & entry : std::filesystem::directory_iterator(path + action_dir)) {
     std::string name = "";
     std::string file_name = entry.path();
-    if (file_name.find(config_name) != std::string::npos) {
-      continue;
-    }
     std::string extension_json = ".json";
-    for (int i = path.length(); i < file_name.length() - extension_json.length(); i++) {
+    for (int i = (path + action_dir).length(); i < file_name.length() - extension_json.length(); i++) {
       name += file_name[i];
     }
 
@@ -109,7 +106,7 @@ void ActionManager::load_config(const std::string & path)
 void ActionManager::set_config(const nlohmann::json & json)
 {
   for (auto &[key, val] : json.items()) {
-    if (key == "dynamic kick") {
+    if (key == "dynamic_kick") {
       try {
         val.at("right_map_x_min").get_to(right_map_x_min);
         val.at("right_map_x_max").get_to(right_map_x_max);
@@ -206,14 +203,16 @@ void ActionManager::start(std::string action_name, std::string target_action_nam
     for (int pose_index = 0; pose_index < action.get_pose_count(); pose_index++) {
       if (right)
       {
+        RCLCPP_INFO(rclcpp::get_logger("DEBUG ACTION MANAGER"), "CEK1");
         action.map_action(action, target_action, pose_index, ball_x, right_map_x_min_, right_map_x_max_);
       } else {
+        RCLCPP_INFO(rclcpp::get_logger("DEBUG ACTION MANAGER"), "CEK1");
         action.map_action(action, target_action, pose_index, ball_x, left_map_x_min_, left_map_x_max_);
       }
     }
 
     target_actions.push_back(action);
-
+    RCLCPP_INFO(rclcpp::get_logger("DEBUG ACTION MANAGER"), "CEK");
     if (action.get_next_action() != "") {
       std::string next_action_name = action.get_next_action();
 

--- a/src/akushon/action/node/action_node.cpp
+++ b/src/akushon/action/node/action_node.cpp
@@ -91,16 +91,10 @@ ActionNode::ActionNode(
     brake_action_topic(), 10,
     [this](std::shared_ptr<Empty> message) {this->action_manager->brake();});
   
-  ball_subscriber = node->create_subscription<rcl_interfaces::msg::ParameterEvent>(
-    ball_topic(), 10, [this](const std::shared_ptr<rcl_interfaces::msg::ParameterEvent> message) {
-      for (const auto &p : message->new_parameters) {
-        if (p.name == "x") {
-          ball_pos.x = p.value.double_value;
-        }
-        else if (p.name == "y") {
-          ball_pos.y = p.value.double_value;
-        }
-      }
+  ball_subscriber = node->create_subscription<Float64>(
+    ball_topic(), 10, [this](const std::shared_ptr<Float64> message) {
+      ball_pos = message->data;
+      std::cout << "BALL_POS: " << ball_pos << std::endl;
     });
 }
 
@@ -120,7 +114,7 @@ bool ActionNode::start(const std::string & action_name)
         source_action = action_name;
       }
 
-      action_manager->start(source_action, action_name, pose, ball_pos.x, 100.0, 100.0, 100.0, 100.0, true); // TODO: Pass ball x to here
+      action_manager->start(source_action, action_name, pose, ball_pos, 100.0, 100.0, 100.0, 100.0, true); // TODO: Pass ball x to here
     }
     else {
       action_manager->start(action_name, pose);

--- a/src/akushon/action/node/action_node.cpp
+++ b/src/akushon/action/node/action_node.cpp
@@ -94,7 +94,6 @@ ActionNode::ActionNode(
   ball_subscriber = node->create_subscription<Float64>(
     ball_topic(), 10, [this](const std::shared_ptr<Float64> message) {
       ball_pos = message->data;
-      std::cout << "BALL_POS: " << ball_pos << std::endl;
     });
 }
 
@@ -107,6 +106,7 @@ bool ActionNode::start(const std::string & action_name)
     {
       std::size_t pos = action_name.find("_WIDE");
       std::string source_action;
+      bool right = false;
     
       if (pos != std::string::npos) {
         source_action = action_name.substr(0, pos);
@@ -114,7 +114,15 @@ bool ActionNode::start(const std::string & action_name)
         source_action = action_name;
       }
 
-      action_manager->start(source_action, action_name, pose, ball_pos, 100.0, 100.0, 100.0, 100.0, true); // TODO: Pass ball x to here
+      if (source_action == "RIGHT_KICK") {
+        right = true;
+      }
+      // Print source_action, action_name, and right
+      RCLCPP_INFO(rclcpp::get_logger("DEBUG"), "source_action: %s, action_name: %s, right: %s", source_action.c_str(), action_name.c_str(), right ? "true" : "false");
+      if (action_manager->using_dynamic_kick)
+        action_manager->start(source_action, action_name, pose, ball_pos, action_manager->right_map_x_min, action_manager->right_map_x_max, action_manager->left_map_x_min, action_manager->left_map_x_max, right);
+      else
+        action_manager->start(source_action, pose);  
     }
     else {
       action_manager->start(action_name, pose);

--- a/src/akushon/action/node/action_node.cpp
+++ b/src/akushon/action/node/action_node.cpp
@@ -104,7 +104,7 @@ bool ActionNode::start(const std::string & action_name)
   if (!pose.get_joints().empty()) {
     if (action_name == akushon::ActionName::LEFT_KICK_WIDE || action_name == akushon::ActionName::RIGHT_KICK_WIDE)
     {
-      std::size_t pos = action_name.find("_WIDE");
+      std::size_t pos = action_name.find("_wide");
       std::string source_action;
       bool right = false;
     
@@ -114,11 +114,9 @@ bool ActionNode::start(const std::string & action_name)
         source_action = action_name;
       }
 
-      if (source_action == "RIGHT_KICK") {
+      if (source_action == "right_kick") {
         right = true;
       }
-      // Print source_action, action_name, and right
-      RCLCPP_INFO(rclcpp::get_logger("DEBUG"), "source_action: %s, action_name: %s, right: %s", source_action.c_str(), action_name.c_str(), right ? "true" : "false");
       if (action_manager->using_dynamic_kick)
         action_manager->start(source_action, action_name, pose, ball_pos, action_manager->right_map_x_min, action_manager->right_map_x_max, action_manager->left_map_x_min, action_manager->left_map_x_max, right);
       else


### PR DESCRIPTION
## Jira Link: 

## Description

Change the workflow to start an action. When wide kick action is detected, the value of the joint is mapped between normal and wide kick based on the ball x position in the camera. There is also a change to load config and save config, because the structure of `action` folder is now:
action
  - dynamic_kick.json
  - actions
    - left_kick.json
    - init.json
    - walkready.json
    - ...
Work is still in progress.

## Type of Change

- [ ] Bugfix
- [ ] Enhancement
- [X] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [X] Manual tested.

## Checklist:

- [X] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.